### PR TITLE
Add v1 system and analytics read-only APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__/
 /.pytest_cache/
 /.ruff_cache/
 .mypy_cache/
+.egg-info/
 .DS_Store
 .idea/
 .vscode/

--- a/README.md
+++ b/README.md
@@ -23,6 +23,17 @@ python manage.py runserver 0.0.0.0:8000
 
 Visit [`/health`](http://localhost:8000/health) for a readiness probe.
 
+## Endpoints
+- `GET /health` → fast path (no database access)
+- `GET /api/v1/system/health` → public status with version metadata
+- `GET /api/v1/system/ready` → readiness check for DB/cache/Celery (staff-only)
+- `GET /api/v1/analytics/daily` → paginated daily aggregates (staff-only)
+- `GET /api/v1/analytics/events` → paginated analytics events (staff-only)
+
+### API Docs
+- OpenAPI schema: `/api/schema/`
+- Swagger UI: `/api/docs/`
+
 ## Make targets
 - `make install` – install dependencies and set up git hooks
 - `make run` – start the Django development server

--- a/analytics/api.py
+++ b/analytics/api.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from django.utils.dateparse import parse_date
+from rest_framework import permissions, serializers, viewsets
+from rest_framework.pagination import PageNumberPagination
+
+from .models import Event, StatsDaily
+
+
+class DefaultLimitPagination(PageNumberPagination):
+    page_size = 50
+    page_size_query_param = "limit"
+    max_page_size = 200
+
+
+class StatsDailySerializer(serializers.ModelSerializer):
+    class Meta:
+        model = StatsDaily
+        fields = [
+            "id",
+            "day",
+            "rx_started",
+            "rx_delivered",
+            "pay_success",
+            "pay_tat_p50_ms",
+            "pay_tat_p95_ms",
+            "apk_downloads",
+        ]
+
+
+class EventSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Event
+        fields = ["id", "name", "at", "props"]
+
+
+class DailyStatsViewSet(viewsets.ReadOnlyModelViewSet):
+    permission_classes = [permissions.IsAdminUser]
+    serializer_class = StatsDailySerializer
+    pagination_class = DefaultLimitPagination
+    queryset = StatsDaily.objects.all().order_by("-day")
+
+    def get_queryset(self):  # noqa: D401
+        qs = super().get_queryset()
+        from_param = self.request.query_params.get("from")
+        to_param = self.request.query_params.get("to")
+        if from_param:
+            parsed_from = parse_date(from_param)
+            if parsed_from:
+                qs = qs.filter(day__gte=parsed_from)
+        if to_param:
+            parsed_to = parse_date(to_param)
+            if parsed_to:
+                qs = qs.filter(day__lte=parsed_to)
+        return qs
+
+
+class EventViewSet(viewsets.ReadOnlyModelViewSet):
+    permission_classes = [permissions.IsAdminUser]
+    serializer_class = EventSerializer
+    pagination_class = DefaultLimitPagination
+    queryset = Event.objects.all().order_by("-at", "-id")
+
+    def get_queryset(self):  # noqa: D401
+        qs = super().get_queryset()
+        name = self.request.query_params.get("name")
+        if name:
+            qs = qs.filter(name=name)
+        return qs

--- a/apps/system/views.py
+++ b/apps/system/views.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+from uuid import uuid4
+
+from celery import current_app as celery_app
+from django.conf import settings
+from django.core.cache import cache
+from django.db import connection
+from django.http import JsonResponse
+from django.utils import timezone
+from rest_framework.permissions import AllowAny, IsAdminUser
+from rest_framework.views import APIView
+
+logger = logging.getLogger(__name__)
+
+
+def _version() -> str:
+    env_version = os.getenv("HELSSA_VERSION")
+    if env_version:
+        return env_version
+    setting_version = getattr(settings, "APP_VERSION", None)
+    if setting_version:
+        return str(setting_version)
+    try:
+        return (
+            subprocess.check_output(["git", "describe", "--tags", "--abbrev=0"], text=True)
+            .strip()
+            or "v2.0.0"
+        )
+    except Exception:  # pragma: no cover - git may be absent
+        return "v2.0.0"
+
+
+class SystemHealthView(APIView):
+    permission_classes = [AllowAny]
+    authentication_classes = ()
+
+    def get(self, request, *args, **kwargs):  # noqa: D401
+        return JsonResponse(
+            {"status": "ok", "time": timezone.now().isoformat(), "version": _version()}
+        )
+
+
+class SystemReadyView(APIView):
+    permission_classes = [IsAdminUser]
+
+    def get(self, request, *args, **kwargs):
+        components = {}
+        status_code = 200
+
+        try:
+            connection.ensure_connection()
+            components["db"] = {"status": "ok"}
+        except Exception as exc:  # pragma: no cover - difficult to simulate
+            components["db"] = {"status": "fail", "error": exc.__class__.__name__}
+            logger.exception("database readiness check failed")
+            status_code = 503
+
+        try:
+            probe_key = f"ready-probe-{uuid4()}"
+            cache.set(probe_key, "1", timeout=1)
+            cache_ok = cache.get(probe_key) == "1"
+            cache.delete(probe_key)
+            components["cache"] = {"status": "ok" if cache_ok else "fail"}
+            if not cache_ok:
+                status_code = 503
+        except Exception as exc:  # pragma: no cover - cache misconfig rare
+            components["cache"] = {"status": "fail", "error": exc.__class__.__name__}
+            logger.exception("cache readiness check failed")
+            status_code = 503
+
+        try:
+            workers = celery_app.control.ping(timeout=1.0)
+            celery_ok = bool(workers)
+            components["celery"] = {"status": "ok" if celery_ok else "fail", "workers": workers}
+            if not celery_ok:
+                status_code = 503
+        except Exception as exc:  # pragma: no cover - broker unavailable
+            components["celery"] = {"status": "fail", "error": exc.__class__.__name__}
+            logger.exception("celery readiness check failed")
+            status_code = 503
+
+        if status_code == 503:
+            logger.warning("system readiness degraded", extra={"components": components})
+
+        return JsonResponse(
+            {"status": "ok" if status_code == 200 else "degraded", "components": components},
+            status=status_code,
+        )

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -31,6 +31,7 @@ INSTALLED_APPS = [
     "drf_spectacular",
     "corsheaders",
     "apps.common",
+    "apps.system",
     "analytics",
 ]
 
@@ -97,6 +98,11 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 REST_FRAMEWORK = {
     "DEFAULT_RENDERER_CLASSES": ["rest_framework.renderers.JSONRenderer"],
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
+    "DEFAULT_PERMISSION_CLASSES": [
+        "rest_framework.permissions.AllowAny",
+    ],
+    "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
+    "PAGE_SIZE": 50,
 }
 
 SPECTACULAR_SETTINGS = {

--- a/config/urls.py
+++ b/config/urls.py
@@ -1,12 +1,22 @@
 from django.contrib import admin
-from django.urls import path
+from django.urls import include, path
 from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
+from rest_framework.routers import DefaultRouter
 
+from analytics.api import DailyStatsViewSet, EventViewSet
 from apps.common.views import health
+from apps.system.views import SystemHealthView, SystemReadyView
+
+router = DefaultRouter()
+router.register(r"analytics/daily", DailyStatsViewSet, basename="analytics-daily")
+router.register(r"analytics/events", EventViewSet, basename="analytics-events")
 
 urlpatterns = [
     path("admin/", admin.site.urls),
-    path("schema/", SpectacularAPIView.as_view(), name="schema"),
-    path("docs/", SpectacularSwaggerView.as_view(url_name="schema"), name="docs"),
     path("health", health, name="health"),
+    path("api/v1/system/health", SystemHealthView.as_view(), name="system-health"),
+    path("api/v1/system/ready", SystemReadyView.as_view(), name="system-ready"),
+    path("api/v1/", include(router.urls)),
+    path("api/schema/", SpectacularAPIView.as_view(), name="schema"),
+    path("api/docs/", SpectacularSwaggerView.as_view(url_name="schema"), name="swagger-ui"),
 ]

--- a/tests/api/test_analytics_endpoints.py
+++ b/tests/api/test_analytics_endpoints.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+from rest_framework.test import APIClient
+
+from analytics.models import Event, StatsDaily
+
+pytestmark = pytest.mark.django_db
+
+
+def test_daily_stats_requires_staff_and_filters(django_user_model):
+    client = APIClient()
+    assert client.get("/api/v1/analytics/daily/").status_code in {401, 403}
+
+    user = django_user_model.objects.create_superuser(
+        username="staff", email="staff@example.com", password="pass"
+    )
+    client.force_authenticate(user=user)
+
+    StatsDaily.objects.create(day=date(2025, 9, 25), pay_success=1)
+    StatsDaily.objects.create(day=date(2025, 9, 26), pay_success=3)
+
+    response = client.get("/api/v1/analytics/daily/?from=2025-09-26&to=2025-09-26")
+    payload = response.json()
+    assert response.status_code == 200
+    assert payload["count"] == 1
+    assert payload["results"][0]["pay_success"] == 3
+
+
+def test_events_filter_and_limit(django_user_model):
+    user = django_user_model.objects.create_superuser(
+        username="staff2", email="staff2@example.com", password="pass"
+    )
+    client = APIClient()
+    client.force_authenticate(user=user)
+
+    for idx in range(5):
+        Event.objects.create(name="pay_success", props={"idx": idx})
+
+    response = client.get("/api/v1/analytics/events/?name=pay_success&limit=3")
+    payload = response.json()
+    assert response.status_code == 200
+    assert len(payload["results"]) <= 3
+    assert all(item["name"] == "pay_success" for item in payload["results"])

--- a/tests/api/test_system_endpoints.py
+++ b/tests/api/test_system_endpoints.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import pytest
+from rest_framework.test import APIClient
+
+pytestmark = pytest.mark.django_db
+
+
+def _fake_celery(response):
+    class _Control:
+        def ping(self, timeout: float = 1.0):
+            return response
+
+    return type("Celery", (), {"control": _Control()})()
+
+
+def _auth_client(user):
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return client
+
+
+def test_system_health_public_headers():
+    response = APIClient().get("/api/v1/system/health")
+    body = response.json()
+    assert response.status_code == 200 and body["status"] == "ok"
+    assert "version" in body and "X-Request-ID" in response
+    assert "X-Response-Time-ms" in response
+
+
+def test_system_ready_requires_staff(django_user_model):
+    client = APIClient()
+    assert client.get("/api/v1/system/ready").status_code in {401, 403}
+
+    user = django_user_model.objects.create_user(
+        username="regular", email="regular@example.com", password="pass"
+    )
+    client.force_authenticate(user=user)
+    assert client.get("/api/v1/system/ready").status_code == 403
+
+
+@pytest.mark.parametrize(
+    "celery_response, expected_status",
+    [([{"ok": True}], 200), ([], 503)],
+)
+def test_system_ready_status(monkeypatch, django_user_model, celery_response, expected_status):
+    monkeypatch.setattr("apps.system.views.celery_app", _fake_celery(celery_response))
+    user = django_user_model.objects.create_superuser(
+        username="admin", email="admin@example.com", password="pass"
+    )
+    response = _auth_client(user).get("/api/v1/system/ready")
+
+    assert response.status_code == expected_status
+    payload = response.json()
+    assert payload["status"] == ("ok" if expected_status == 200 else "degraded")
+    assert "components" in payload


### PR DESCRIPTION
## Summary
- add `/api/v1/system/health` and `/api/v1/system/ready` endpoints with version reporting and readiness checks
- expose staff-gated analytics daily stats and events read APIs with pagination and filtering
- wire DRF router, OpenAPI/Swagger docs, and document the new endpoints with tests ensuring access control

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d924dd99dc83208ed7b36553f2de70