### PR TITLE
Add repository structure report tooling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install run celery test lint format migrate redis-up redis-down save-log save-log-file save-log-commit
+.PHONY: install run celery test lint format migrate redis-up redis-down save-log save-log-file save-log-commit repo-struct repo-struct-out
 
 install:
 	python -m pip install --upgrade pip
@@ -50,4 +50,10 @@ endif
 	python scripts/save_log.py --input "$(FILE)" $(if $(TAG),--tag "$(TAG)",)
 
 save-log-commit:
-	python scripts/save_log.py $(if $(TAG),--tag "$(TAG)",) --commit
+        python scripts/save_log.py $(if $(TAG),--tag "$(TAG)",) --commit
+
+repo-struct:
+	python scripts/repo_tree_report.py
+
+repo-struct-out:
+	python scripts/repo_tree_report.py --out docs/REPO_STRUCTURE.md

--- a/docs/REPO_STRUCTURE.md
+++ b/docs/REPO_STRUCTURE.md
@@ -1,0 +1,255 @@
+# Repository Structure Report (2025-10-03 19:48:51Z)
+
+- **Version:** v0.0.0
+- **Branch:** work
+- **Recent commits:**
+  - 5ceb6cf Merge pull request #15 from mehran-shabani/codex/add-generic-log-capture-utility
+  - 0f070a6 chore: add log capture utility
+  - 39426af Merge pull request #14 from mehran-shabani/codex/stabilize-helssa-dev-environment
+  - 8cf6a70 Update apps/ops/management/commands/bootstrap_dev.py
+  - b85ef55 feat: add dev bootstrap helpers
+
+## Summary
+| Metric | Value |
+| --- | --- |
+| Total files | 88 |
+| Total size | 98.6 KB |
+| Total LOC | 2991 |
+| Python files | 64 |
+| Test files | 10 |
+
+## Tree View
+```text
+helssa-2.0
+├── .github
+│   ├── ISSUE_TEMPLATE
+│   │   ├── bug_report.yml
+│   │   ├── feature_request.yml
+│   │   └── task.yml
+│   ├── workflows
+│   │   ├── ci.yml
+│   │   └── release.yml
+│   ├── dependabot.yml
+│   └── PULL_REQUEST_TEMPLATE.md
+├── analytics
+│   ├── migrations
+│   │   ├── 0001_initial.py
+│   │   ├── 0002_event_stats_indexes.py
+│   │   └── __init__.py
+│   ├── __init__.py
+│   ├── admin.py
+│   ├── api.py
+│   ├── apps.py
+│   └── models.py
+├── apps
+│   ├── common
+│   │   ├── __init__.py
+│   │   ├── apps.py
+│   │   └── views.py
+│   ├── ops
+│   │   ├── management
+│   │   │   ├── commands
+│   │   │   │   ├── __init__.py
+│   │   │   │   ├── bootstrap_dev.py
+│   │   │   │   └── diag_probe.py
+│   │   │   └── __init__.py
+│   │   ├── __init__.py
+│   │   └── apps.py
+│   └── system
+│       ├── __init__.py
+│       └── views.py
+├── config
+│   ├── settings
+│   │   ├── base.py
+│   │   ├── dev.py
+│   │   ├── prod.py
+│   │   └── test.py
+│   ├── __init__.py
+│   ├── asgi.py
+│   ├── celery.py
+│   ├── urls.py
+│   └── wsgi.py
+├── core
+│   ├── middleware
+│   │   └── request_id.py
+│   ├── __init__.py
+│   └── logging.py
+├── docs
+├── helssa.egg-info
+│   ├── dependency_links.txt
+│   ├── PKG-INFO
+│   ├── requires.txt
+│   ├── SOURCES.txt
+│   └── top_level.txt
+├── perf
+│   ├── management
+│   │   ├── commands
+│   │   │   ├── __init__.py
+│   │   │   └── perf_slowlog.py
+│   │   └── __init__.py
+│   ├── __init__.py
+│   ├── apps.py
+│   ├── metrics.py
+│   ├── tasks.py
+│   └── views.py
+├── scripts
+│   ├── bump_version.py
+│   ├── changelog.py
+│   ├── repo_tree_report.py
+│   ├── save_log.py
+│   └── setup.sh
+├── telemedicine
+│   ├── gateway
+│   │   ├── __init__.py
+│   │   ├── bitpay.py
+│   │   └── signature.py
+│   ├── migrations
+│   │   ├── 0001_initial.py
+│   │   ├── 0002_transaction_indexes.py
+│   │   └── __init__.py
+│   ├── __init__.py
+│   ├── admin.py
+│   ├── apps.py
+│   ├── models.py
+│   └── views.py
+├── tests
+│   ├── api
+│   │   ├── test_analytics_endpoints.py
+│   │   └── test_system_endpoints.py
+│   ├── payments
+│   │   ├── __init__.py
+│   │   ├── test_idempotency.py
+│   │   └── test_signature_and_errors.py
+│   ├── test_analytics_models.py
+│   ├── test_health.py
+│   ├── test_perf.py
+│   └── test_request_id_mw.py
+├── .cz.yaml
+├── .editorconfig
+├── .env.example
+├── .gitignore
+├── .pre-commit-config.yaml
+├── CHANGELOG.md
+├── docker-compose.dev.yml
+├── Makefile
+├── manage.py
+├── pyproject.toml
+├── pytest.ini
+└── README.md
+```
+
+## Files
+| Path | Kind | LOC | Size | Note |
+| --- | --- | --- | --- | --- |
+| .cz.yaml | YAML | 7 | 162 B |  |
+| .editorconfig | Other | 12 | 187 B |  |
+| .env.example | EXAMPLE | 15 | 520 B |  |
+| .github/ISSUE_TEMPLATE/bug_report.yml | YAML | 18 | 538 B |  |
+| .github/ISSUE_TEMPLATE/feature_request.yml | YAML | 11 | 313 B |  |
+| .github/ISSUE_TEMPLATE/task.yml | YAML | 8 | 170 B |  |
+| .github/PULL_REQUEST_TEMPLATE.md | Markdown | 17 | 224 B | Summary |
+| .github/dependabot.yml | YAML | 10 | 197 B |  |
+| .github/workflows/ci.yml | YAML | 27 | 676 B |  |
+| .github/workflows/release.yml | YAML | 36 | 1.1 KB |  |
+| .gitignore | Other | 17 | 187 B |  |
+| .pre-commit-config.yaml | YAML | 15 | 366 B |  |
+| CHANGELOG.md | Markdown | 4 | 57 B | Changelog |
+| Makefile | Other | 59 | 1.5 KB |  |
+| README.md | Markdown | 134 | 5.3 KB | Helssa 2.0 |
+| analytics/__init__.py | Python | 1 | 31 B | Analytics domain models. |
+| analytics/admin.py | Python | 16 | 417 B |  |
+| analytics/api.py | Python | 105 | 4.2 KB |  |
+| analytics/apps.py | Python | 6 | 150 B |  |
+| analytics/migrations/0001_initial.py | Python | 62 | 2.1 KB |  |
+| analytics/migrations/0002_event_stats_indexes.py | Python | 25 | 581 B |  |
+| analytics/migrations/__init__.py | Python | 0 | 0 B |  |
+| analytics/models.py | Python | 26 | 971 B |  |
+| apps/common/__init__.py | Python | 1 | 28 B | Common utilities app. |
+| apps/common/apps.py | Python | 6 | 149 B |  |
+| apps/common/views.py | Python | 5 | 102 B |  |
+| apps/ops/__init__.py | Python | 0 | 0 B |  |
+| apps/ops/apps.py | Python | 6 | 125 B |  |
+| apps/ops/management/__init__.py | Python | 0 | 0 B |  |
+| apps/ops/management/commands/__init__.py | Python | 0 | 0 B |  |
+| apps/ops/management/commands/bootstrap_dev.py | Python | 37 | 1.4 KB |  |
+| apps/ops/management/commands/diag_probe.py | Python | 252 | 8.9 KB |  |
+| apps/system/__init__.py | Python | 0 | 0 B |  |
+| apps/system/views.py | Python | 143 | 6.8 KB |  |
+| config/__init__.py | Python | 3 | 65 B |  |
+| config/asgi.py | Python | 9 | 226 B |  |
+| config/celery.py | Python | 8 | 225 B |  |
+| config/settings/base.py | Python | 162 | 5.0 KB |  |
+| config/settings/dev.py | Python | 5 | 129 B |  |
+| config/settings/prod.py | Python | 10 | 334 B |  |
+| config/settings/test.py | Python | 17 | 520 B |  |
+| config/urls.py | Python | 42 | 1.5 KB |  |
+| config/wsgi.py | Python | 9 | 227 B |  |
+| core/__init__.py | Python | 1 | 37 B | Core infrastructure utilities. |
+| core/logging.py | Python | 38 | 1.3 KB |  |
+| core/middleware/request_id.py | Python | 20 | 657 B |  |
+| docker-compose.dev.yml | YAML | 9 | 165 B |  |
+| helssa.egg-info/PKG-INFO | Other | 103 | 3.5 KB |  |
+| helssa.egg-info/SOURCES.txt | Text | 22 | 463 B |  |
+| helssa.egg-info/dependency_links.txt | Text | 1 | 1 B |  |
+| helssa.egg-info/requires.txt | Text | 21 | 237 B |  |
+| helssa.egg-info/top_level.txt | Text | 5 | 33 B |  |
+| manage.py | Python | 14 | 286 B | !/usr/bin/env python |
+| perf/__init__.py | Python | 0 | 0 B |  |
+| perf/apps.py | Python | 6 | 140 B |  |
+| perf/management/__init__.py | Python | 0 | 0 B |  |
+| perf/management/commands/__init__.py | Python | 0 | 0 B |  |
+| perf/management/commands/perf_slowlog.py | Python | 92 | 3.3 KB |  |
+| perf/metrics.py | Python | 41 | 1.1 KB |  |
+| perf/tasks.py | Python | 15 | 359 B |  |
+| perf/views.py | Python | 12 | 297 B |  |
+| pyproject.toml | TOML | 61 | 1.2 KB |  |
+| pytest.ini | INI | 4 | 121 B |  |
+| scripts/bump_version.py | Python | 36 | 951 B | !/usr/bin/env python3 |
+| scripts/changelog.py | Python | 57 | 1.9 KB | !/usr/bin/env python3 |
+| scripts/repo_tree_report.py | Python | 193 | 8.5 KB | Generate a repository structure report in Markdown. |
+| scripts/save_log.py | Python | 117 | 3.5 KB | Save diagnostic logs to docs/PROJECT_LOG.md and project_logs/. |
+| scripts/setup.sh | Shell | 27 | 667 B |  |
+| telemedicine/__init__.py | Python | 0 | 0 B |  |
+| telemedicine/admin.py | Python | 16 | 445 B |  |
+| telemedicine/apps.py | Python | 6 | 156 B |  |
+| telemedicine/gateway/__init__.py | Python | 0 | 0 B |  |
+| telemedicine/gateway/bitpay.py | Python | 19 | 492 B |  |
+| telemedicine/gateway/signature.py | Python | 30 | 1.1 KB |  |
+| telemedicine/migrations/0001_initial.py | Python | 30 | 852 B |  |
+| telemedicine/migrations/0002_transaction_indexes.py | Python | 54 | 1.3 KB |  |
+| telemedicine/migrations/__init__.py | Python | 0 | 0 B |  |
+| telemedicine/models.py | Python | 15 | 378 B |  |
+| telemedicine/views.py | Python | 170 | 5.9 KB |  |
+| tests/api/test_analytics_endpoints.py | Python | 54 | 2.2 KB |  |
+| tests/api/test_system_endpoints.py | Python | 89 | 3.5 KB |  |
+| tests/payments/__init__.py | Python | 0 | 0 B |  |
+| tests/payments/test_idempotency.py | Python | 53 | 2.0 KB |  |
+| tests/payments/test_signature_and_errors.py | Python | 82 | 2.6 KB |  |
+| tests/test_analytics_models.py | Python | 23 | 664 B |  |
+| tests/test_health.py | Python | 13 | 345 B |  |
+| tests/test_perf.py | Python | 68 | 1.9 KB |  |
+| tests/test_request_id_mw.py | Python | 28 | 783 B |  |
+
+## Notable Configs
+- `.editorconfig`
+- `.env.example`
+- `.github/workflows/ci.yml`
+- `.github/workflows/release.yml`
+- `Makefile`
+- `README.md`
+- `docker-compose.dev.yml`
+- `pyproject.toml`
+- `pytest.ini`
+
+## URL Patterns (Quick Scan)
+- `config/urls.py`
+  - `admin/`
+  - `health`
+  - `api/v1/system/health`
+  - `api/v1/system/ready`
+  - `api/v1/`
+  - `api/schema/`
+  - `api/docs/`
+  - `telemedicine/pay/webhook`
+  - `telemedicine/pay/verify`
+  - `metrics`

--- a/scripts/repo_tree_report.py
+++ b/scripts/repo_tree_report.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Generate a repository structure report in Markdown."""
+from __future__ import annotations
+
+import argparse
+import ast
+from datetime import datetime, timezone
+import os
+from pathlib import Path
+import re
+import subprocess
+
+IGNORE_DIRS = {".git", "__pycache__", ".mypy_cache", ".ruff_cache", "node_modules", "dist", "build", "htmlcov", ".reports", "project_logs", ".pytest_cache", ".venv", "venv"}
+KIND_MAP = {".py": "Python", ".md": "Markdown", ".rst": "ReST", ".txt": "Text", ".json": "JSON", ".yml": "YAML", ".yaml": "YAML", ".toml": "TOML", ".ini": "INI", ".cfg": "Config", ".env": "Env", ".sh": "Shell"}
+NOTABLE_CONFIGS = ["pyproject.toml", "README.md", "Dockerfile", "Makefile", "pytest.ini", "ruff.toml", ".editorconfig", ".env.example"]
+URL_REGEX = re.compile(r"(?:path|re_path)\(\s*[rR]?[\"']([^\"']+)")
+
+def iter_files(root):
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d not in IGNORE_DIRS]
+        for name in filenames:
+            yield Path(dirpath) / name
+
+def human_size(size):
+    value = float(size)
+    for unit in ("B", "KB", "MB", "GB"):
+        if value < 1024 or unit == "GB":
+            return f"{value:.1f} {unit}" if unit != "B" else f"{int(value)} {unit}"
+        value /= 1024
+    return f"{value:.1f} GB"
+
+def build_tree(root, max_depth):
+    def walk(path, prefix, depth, out):
+        if depth >= max_depth:
+            return
+        entries = sorted([p for p in path.iterdir() if p.name not in IGNORE_DIRS], key=lambda p: (p.is_file(), p.name.lower()))
+        for idx, entry in enumerate(entries):
+            branch = "└── " if idx == len(entries) - 1 else "├── "
+            out.append(f"{prefix}{branch}{entry.name}")
+            if entry.is_dir():
+                walk(entry, prefix + ("    " if idx == len(entries) - 1 else "│   "), depth + 1, out)
+
+    lines = [root.name or "."]
+    walk(root, "", 0, lines)
+    return "\n".join(lines)
+
+def run_cmd(args):
+    try:
+        proc = subprocess.run(args, capture_output=True, text=True, check=False)
+        return proc.returncode, proc.stdout.strip()
+    except OSError:
+        return 1, ""
+
+def git_info(root):
+    version = os.getenv("HELSSA_VERSION")
+    branch = "unknown"
+    commits = []
+    if not version:
+        code, out = run_cmd(["git", "-C", str(root), "describe", "--tags", "--abbrev=0"])
+        if code == 0 and out:
+            version = out
+        else:
+            code, out = run_cmd(["git", "-C", str(root), "tag", "--sort=-creatordate"])
+            version = out.splitlines()[0] if code == 0 and out else "v0.0.0"
+    code, out = run_cmd(["git", "-C", str(root), "rev-parse", "--abbrev-ref", "HEAD"])
+    if code == 0 and out:
+        branch = out
+    code, out = run_cmd(["git", "-C", str(root), "log", "-5", "--pretty=format:%h %s"])
+    if code == 0 and out:
+        commits = out.splitlines()
+    return version or "v0.0.0", branch, commits
+
+def truncate(text, width=80):
+    if len(text) <= width:
+        return text
+    keep = width - 3
+    left = keep // 2
+    right = keep - left
+    return f"{text[:left]}...{text[-right:]}"
+
+def collect_data(root):
+    files = []
+    summary = {"total_files": 0, "total_size": 0, "total_loc": 0, "python_files": 0, "test_files": 0}
+    url_map = {}
+    for abs_path in iter_files(root):
+        rel = abs_path.relative_to(root).as_posix()
+        try:
+            size = abs_path.stat().st_size
+        except OSError:
+            continue
+        kind = KIND_MAP.get(abs_path.suffix.lower(), abs_path.suffix[1:].upper() if abs_path.suffix else "Other")
+        try:
+            text = abs_path.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            text = None
+        loc = text.count("\n") + (1 if text and not text.endswith("\n") else 0) if text else 0
+        note = ""
+        if text:
+            if kind == "Python":
+                try:
+                    doc = ast.get_docstring(ast.parse(text))
+                    if doc:
+                        note = " ".join(doc.split())
+                    else:
+                        first = next((ln.strip() for ln in text.splitlines() if ln.strip()), "")
+                        note = first.lstrip("# ") if first.startswith("#") else ""
+                except SyntaxError:
+                    pass
+            elif kind == "Markdown":
+                heading = next((ln.strip() for ln in text.splitlines() if ln.strip().startswith("#")), "")
+                if heading:
+                    note = heading.lstrip("# ").strip()
+            elif kind in {"YAML", "TOML", "INI", "Config"}:
+                comment = next((ln.strip() for ln in text.splitlines() if ln.strip().startswith("#")), "")
+                if comment:
+                    note = comment.lstrip("# ")
+            if abs_path.name == "urls.py":
+                matches = URL_REGEX.findall(text)
+                if matches:
+                    url_map[rel] = matches
+        files.append((rel, kind, loc, size, note))
+        summary["total_files"] += 1
+        summary["total_size"] += size
+        summary["total_loc"] += loc
+        if kind == "Python":
+            summary["python_files"] += 1
+            if "test" in rel.lower():
+                summary["test_files"] += 1
+    return files, summary, url_map
+
+def generate_report(root, out_path, max_depth, limit, sort_key, show_tree, show_table):
+    files, summary, url_map = collect_data(root)
+    version, branch, commits = git_info(root)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%SZ")
+    lines = [f"# Repository Structure Report ({timestamp})", "", f"- **Version:** {version}", f"- **Branch:** {branch}"]
+    if commits:
+        lines.append("- **Recent commits:**")
+        lines.extend(f"  - {c}" for c in commits)
+    lines.extend(["", "## Summary", "| Metric | Value |", "| --- | --- |", f"| Total files | {summary['total_files']} |", f"| Total size | {human_size(summary['total_size'])} |", f"| Total LOC | {summary['total_loc']} |", f"| Python files | {summary['python_files']} |", f"| Test files | {summary['test_files']} |"])
+    if show_tree:
+        lines.extend(["", "## Tree View", "```text", build_tree(root, max_depth), "```"])
+    if show_table:
+        key_funcs = {
+            "path": lambda item: item[0],
+            "loc": lambda item: (-item[2], item[0]),
+            "size": lambda item: (-item[3], item[0]),
+        }
+        ordered = sorted(files, key=key_funcs[sort_key])
+        truncated = len(ordered) > limit
+        rows = ordered[:limit]
+        lines.extend(["", "## Files", "| Path | Kind | LOC | Size | Note |", "| --- | --- | --- | --- | --- |"])
+        for rel, kind, loc, size, note in rows:
+            lines.append(f"| {truncate(rel)} | {kind} | {loc} | {human_size(size)} | {truncate(note)} |")
+        if truncated:
+            lines.extend(["", f"_Table truncated to first {limit} files._"])
+    configs = [cfg for cfg in NOTABLE_CONFIGS if (root / cfg).exists()]
+    workflows = root / ".github" / "workflows"
+    if workflows.exists():
+        configs += [str(p.relative_to(root)) for p in workflows.glob("*.yml")]
+    configs += [str(p.relative_to(root)) for p in root.glob("docker-compose*.yml")]
+    if configs:
+        lines.append("")
+        lines.append("## Notable Configs")
+        for cfg in sorted(configs):
+            lines.append(f"- `{cfg}`")
+    if url_map:
+        lines.append("")
+        lines.append("## URL Patterns (Quick Scan)")
+        for rel in sorted(url_map):
+            lines.append(f"- `{rel}`")
+            for pattern in url_map[rel]:
+                lines.append(f"  - `{pattern}`")
+    out_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+def parse_args(argv=None):
+    parser = argparse.ArgumentParser(description="Generate repository structure report")
+    parser.add_argument("--out", default="docs/REPO_STRUCTURE.md", help="Output Markdown path")
+    parser.add_argument("--max-depth", type=int, default=6, help="Maximum depth for tree view")
+    parser.add_argument("--limit", type=int, default=2000, help="Maximum number of files in table")
+    parser.add_argument("--sort", choices=["path", "loc", "size"], default="path", help="Sort column for file table")
+    parser.add_argument("--no-tree", action="store_true", help="Disable tree view")
+    parser.add_argument("--no-table", action="store_true", help="Disable file table")
+    return parser.parse_args(argv)
+
+def main(argv=None):
+    args = parse_args(argv)
+    root = Path.cwd()
+    generate_report(root, root / args.out, args.max_depth, args.limit, args.sort, not args.no_tree, not args.no_table)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a repository structure reporting script that builds a tree, per-file metadata, git info, and URL pattern summary
- add Makefile helpers and check in the generated docs/REPO_STRUCTURE.md snapshot

## Testing
- python scripts/repo_tree_report.py --out docs/REPO_STRUCTURE.md

------
https://chatgpt.com/codex/tasks/task_e_68e0276f71208320b3c66aed6a1037e2