### PR TITLE
fix: handle changelog generation without tags

### DIFF
--- a/scripts/changelog.py
+++ b/scripts/changelog.py
@@ -17,8 +17,10 @@ def last_tag() -> str:
         return ""
 
 def commits_since(tag: str) -> list[str]:
-    rev = f"{tag}.." if tag else ""
-    out = subprocess.check_output(["git", "log", "--pretty=%s", rev], text=True)
+    command = ["git", "log", "--pretty=%s"]
+    if tag:
+        command.append(f"{tag}..")
+    out = subprocess.check_output(command, text=True)
     return [line.strip() for line in out.splitlines() if line.strip()]
 
 def group(commits: Iterable[str]) -> dict[str, list[str]]:


### PR DESCRIPTION
## Summary
- avoid passing an empty revision to `git log` when the repository has no tags so the changelog script can run successfully

## Testing
- python -m compileall scripts/changelog.py

------
https://chatgpt.com/codex/tasks/task_e_68e0f59497a88320af9c8d17dc63e52d