### PR TITLE
Restrict release workflow to main branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,8 @@
 name: Release (minor bump)
 on:
   push:
-    branches: ["**"]
+    branches:
+      - main
 permissions:
   contents: write
   pull-requests: write


### PR DESCRIPTION
## Summary
- limit the automated release workflow to only run on pushes to the main branch to prevent duplicate tag attempts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0f6b6f1088320ac79879dfcda43e9