### PR TITLE
chore: bump project version to v2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v2.3.0 - 2025-10-04
+- chore: reset release baseline to start from v2.3.0 and increment patch versions by 0.01
+
 ## v2.0.0 - 2024-01-01
 - Bootstrap baseline
 ## v2.1.0 - 2025-10-04

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "helssa"
-version = "2.2.0"
+version = "2.3.0"
 description = "Helssa 2.0 backend service"
 readme = "README.md"
 authors = [{ name = "Helssa Team" }]
@@ -58,7 +58,7 @@ line_length = 100
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "2.2.0"
+version = "2.3.0"
 version_files = ["pyproject.toml:version"]
 tag_format = "v$version"
 update_changelog_on_bump = true


### PR DESCRIPTION
## Summary
- raise the project release baseline to v2.3.0 to avoid existing tag collisions
- note the new release starting point in the changelog

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0f7b2a0a8832080369bb1850f4a6b