### PR TITLE
Fix release version bump to respect latest tag

### DIFF
--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -2,17 +2,39 @@
 import pathlib
 import re
 import subprocess
+from typing import Iterable
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 PYPROJECT = ROOT / "pyproject.toml"
+VERSION_RE = re.compile(r"^v(\d+)\.(\d+)\.(\d+)$")
+DEFAULT_BASE_TAG = "v2.2.0"
+
+
+def _candidate_tags() -> Iterable[str]:
+    try:
+        output = subprocess.check_output(
+            ["git", "tag", "--list", "v[0-9]*.[0-9]*.[0-9]*"],
+            text=True,
+        )
+    except subprocess.CalledProcessError:
+        return []
+    return [line.strip() for line in output.splitlines() if line.strip()]
+
+
+def latest_released_tag() -> str | None:
+    parsed: list[tuple[int, int, int, str]] = []
+    for tag in _candidate_tags():
+        match = VERSION_RE.fullmatch(tag)
+        if match:
+            major, minor, patch = map(int, match.groups())
+            parsed.append((major, minor, patch, tag))
+    if not parsed:
+        return None
+    return max(parsed, key=lambda item: (item[0], item[1], item[2]))[3]
+
 
 def latest_tag() -> str:
-    try:
-        return subprocess.check_output(
-            ["git", "describe", "--tags", "--abbrev=0"], text=True
-        ).strip()
-    except subprocess.CalledProcessError:
-        return "v2.0.0"
+    return latest_released_tag() or DEFAULT_BASE_TAG
 
 def bump_minor(tag: str) -> str:
     m = re.fullmatch(r"v(\d+)\.(\d+)\.(\d+)", tag)

--- a/scripts/changelog.py
+++ b/scripts/changelog.py
@@ -5,16 +5,14 @@ import re
 import subprocess
 from collections.abc import Iterable
 
+import bump_version
+
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 CHANGELOG = ROOT / "CHANGELOG.md"
 
 def last_tag() -> str:
-    try:
-        return subprocess.check_output(
-            ["git", "describe", "--tags", "--abbrev=0"], text=True
-        ).strip()
-    except subprocess.CalledProcessError:
-        return ""
+    tag = bump_version.latest_released_tag()
+    return tag or ""
 
 def commits_since(tag: str) -> list[str]:
     command = ["git", "log", "--pretty=%s"]


### PR DESCRIPTION
## Summary
- ensure the release script determines the next version from the highest existing semver tag
- reuse the new tag discovery logic in the changelog generator so both scripts stay in sync

## Testing
- python -m compileall scripts

------
https://chatgpt.com/codex/tasks/task_e_68e0f926a410832096a6859f77a097af